### PR TITLE
Added second pass through plugboard

### DIFF
--- a/src/enigmaMachine.js
+++ b/src/enigmaMachine.js
@@ -53,6 +53,9 @@ class EnigmaMachine {
       nextInput = this.rotors[i].alpha.indexOf(outputChar);
     }
 
+    // mrpjevans: Final pass through the plugboard
+    nextInput = this.plugboard.indexOf(ALPHABET[nextInput]);
+
     // output
     //console.log(ALPHABET[nextInput] + '/n');
     return ALPHABET[nextInput];


### PR DESCRIPTION
I found the problem I raised as an issue. Enigma machines encode through the plugboard twice, as the first and last stage of encryption. The last stage was absent and adding it corrected the issue I was having.